### PR TITLE
Add JAVA_TOOL_OPTIONS to nexus chart

### DIFF
--- a/charts/nexus/templates/statefulset.yaml
+++ b/charts/nexus/templates/statefulset.yaml
@@ -25,6 +25,8 @@ spec:
       - env:
         - name: INSTALL4J_ADD_VM_PARAMS
           value: {{ .Values.containerJVMParam }}
+        - name: JAVA_TOOL_OPTIONS
+          value: {{ .Values.java_tool_options}}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ .Values.image.name }}

--- a/charts/nexus/values.yaml
+++ b/charts/nexus/values.yaml
@@ -51,3 +51,7 @@ resources:
 
 ## Refer to https://help.sonatype.com/repomanager3/installation/system-requirements#SystemRequirements-ExampleMaximumMemoryConfigurations for value
 containerJVMParam: "-Xms10g -Xmx10g -XX:MaxDirectMemorySize=10g -XX:-MaxFDLimit"
+# This environment variable allows you to specify the initialization of tools, 
+# specifically the launching of native or Java programming language agents using the -agentlib or -javaagent options.
+# https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/envvars002.html
+java_tool_options: ""


### PR DESCRIPTION
Hello!
Add JAVA_TOOL_OPTIONS to nexus chart

Use for example

- https://checkmarx.atlassian.net/wiki/spaces/CCD/pages/2140111061/Setting+up+and+Configuring+the+CxIAST+Java+Agent+on+the+AUT+Environment+v3.7.0+to+v3.9.0
- https://docs.newrelic.com/docs/agents/java-agent/installation/include-java-agent-jvm-argument/