### PR TITLE
Nexus: Set ingress paths as templated values

### DIFF
--- a/charts/nexus/Chart.yaml
+++ b/charts/nexus/Chart.yaml
@@ -3,7 +3,7 @@ name: nexus
 description: Sonatype Nexus is an open source repository manager
 type: application
 appVersion: "3.38.0"
-version: "1.2.3"
+version: "1.2.4"
 home: https://github.com/curie-data-factory/helm-charts/tree/master/charts/nexus
 icon: https://help.sonatype.com/docs/files/331022/34537964/3/1564671303641/NexusRepo_Icon.png
 sources:

--- a/charts/nexus/templates/ingress.yaml
+++ b/charts/nexus/templates/ingress.yaml
@@ -17,7 +17,7 @@ spec:
     - host: {{ .Values.ingress.urldockerrelease }}
       http:
         paths:
-          - path: /
+          - path: {{ .Values.ingress.urlDockerReleasePath }}
             pathType: Prefix
             backend:
               service:
@@ -47,7 +47,7 @@ spec:
     - host: {{ .Values.ingress.urldockersnapshot }}
       http:
         paths:
-          - path: /
+          - path: {{ .Values.ingress.urlDockerSnapshotPath }}
             pathType: Prefix
             backend:
               service:
@@ -81,7 +81,7 @@ spec:
     - host: "{{ .Values.ingress.url }}"
       http:
         paths:
-          - path: /
+          - path: {{ .Values.ingress.urlPath }}
             pathType: Prefix
             backend:
               service:

--- a/charts/nexus/templates/statefulset.yaml
+++ b/charts/nexus/templates/statefulset.yaml
@@ -26,7 +26,9 @@ spec:
         - name: INSTALL4J_ADD_VM_PARAMS
           value: {{ .Values.containerJVMParam }}
         - name: JAVA_TOOL_OPTIONS
-          value: {{ .Values.java_tool_options}}          
+          value: {{ .Values.java_tool_options}}
+        - name: NEXUS_CONTEXT
+          value: {{ .Values.ingress.urlPath | replace "/" "" }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ .Values.image.name }}
@@ -41,7 +43,7 @@ spec:
           name: dockerrelease
           protocol: TCP
         resources:
-{{- toYaml .Values.resources | nindent 12 }}         
+{{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:
         - mountPath: /nexus-data/blobs
           name: "{{ .Release.Name }}-blobs"

--- a/charts/nexus/values.yaml
+++ b/charts/nexus/values.yaml
@@ -15,10 +15,13 @@ service:
 ingress:
   urldockerrelease: nexus-release.company.com
   urldockerreleasename: nexus-release
+  urlDockerReleasePath: /
   urldockersnapshot: nexus-snapshot.company.com
   urldockersnapshotname: nexus-snapshot
+  urlDockerSnapshotPath: /
   enabled: true
   url: nexus.company.com
+  urlPath: /
 
   tls:
   - hosts:


### PR DESCRIPTION
Path part of URL is currently hard-coded to "/".  In other words, can only configure the host part of URL.

Required creating a new env var ["NEXUS_CONTEXT"](https://hub.docker.com/r/sonatype/nexus3#notes). This [must omit ](https://github.com/sonatype/docker-nexus/issues/60#issuecomment-541326131)the leading "/". This PR accepts path values with leading "/", but strips them when rendering the yaml.