### PR TITLE
adding loadbalancer ip for using service type of loadbalancer

### DIFF
--- a/charts/nexus/README.md
+++ b/charts/nexus/README.md
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the chart and their def
 | `image.imagePullSecrets`         | Docker registry credentials Secret name          | `registrysecret`                                                    |
 | `image.dataSecret`               | Secret storing docker image registry credentials | `{"auths":{"registry.compagny.com":{"password":"","username":""}}}` |
 | `service.type`                   | Service Type                                     | `ClusterIP`                                                         |
+| `service.loadBalancerIP`         | Service LoadBalancerIP                           | `nil`                                                               |
 | `service.targetPort`             | Service Port                                     | `80`                                                                |
 | `service.protocol`               | Service Protocol                                 | `TCP`                                                               |
 | `ingress.enabled`                | Expose application with ingress                  | `true`                                                              |

--- a/charts/nexus/templates/service.yaml
+++ b/charts/nexus/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: "{{ .Release.Name }}-{{ .Values.image.name }}"
 spec:
   type: {{ .Values.service.type }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
   ports:
     - name: http
       port: 8081


### PR DESCRIPTION
# Motivation
As I use GKE (Google Kubernetes Engine) I tend to expose a lot of systems via Service based load balancers for which I need to use static/reserved IP addresses therefore it is necessary to set the load balancer IP when using a service type of LoadBalancer.

https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#service_parameters

This feature should be useful for other cloud providers as well.