### PR TITLE
Allow disabling Postgres subchart and using external Postgres instance

### DIFF
--- a/charts/doccano/Chart.yaml
+++ b/charts/doccano/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: doccano
 appVersion: 1.8.0
-version: 2.0.6
+version: 2.0.7
 description: A Helm chart for doccano, Open source text annotation tool for machine learning practitioner.
 home: https://doccano.herokuapp.com/
 icon: https://raw.githubusercontent.com/doccano/doccano/master/docs/images/logo/doccano.png

--- a/charts/doccano/Chart.yaml
+++ b/charts/doccano/Chart.yaml
@@ -13,6 +13,7 @@ maintainers:
 kubeVersion: ">= 1.14.0-0"
 dependencies:
   - name: postgresql
+    condition: postgresql.installAsDependency
     repository: https://charts.bitnami.com/bitnami
     version: 11.8.1
 keywords:

--- a/charts/doccano/README.md
+++ b/charts/doccano/README.md
@@ -57,3 +57,5 @@ The following table lists the configurable parameters of the chart and their def
 | `persistence.replicas`           | PVC storage class replicas (if possible)                             | `1`                                                                 |
 | `persistence.volumeName`         | Directory name                                                       | `data`                                                              |
 | `persistence.mountPath`          | Directory mount path                                                 | `/data`                                                             |
+| `postgresql.installAsDependency` | Install Postgres as a subchart (disable to use an external instance) | `true`                                                              |
+| `postgresql.host`                | Host of the external Postgres instance (if not using internal one)   | `nil`                                                               |

--- a/charts/doccano/templates/_helpers.tpl
+++ b/charts/doccano/templates/_helpers.tpl
@@ -43,3 +43,14 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Create postgres host.
+*/}}
+{{- define "doccano.postgres_host" -}}
+{{- if .Values.postgresql.installAsDependency -}}
+{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 -}}
+{{- else -}}
+{{- .Values.postgresql.host -}}
+{{- end -}}
+{{- end -}}

--- a/charts/doccano/templates/deployment.yaml
+++ b/charts/doccano/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
               name: doccano-password
               optional: false
         - name: DATABASE_URL
-          value: "postgres://{{ .Values.postgresql.global.postgresql.auth.username }}:{{ .Values.postgresql.global.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.global.postgresql.auth.database }}?sslmode=disable"
+          value: "postgres://{{ .Values.postgresql.global.postgresql.auth.username }}:{{ .Values.postgresql.global.postgresql.auth.password }}@{{ include "doccano.postgres_host" . }}:5432/{{ .Values.postgresql.global.postgresql.auth.database }}?sslmode=disable"
         {{- if .Values.extraEnv }}
         {{- with .Values.extraEnv }}
 {{ toYaml . | indent 8 }}

--- a/charts/doccano/values.yaml
+++ b/charts/doccano/values.yaml
@@ -43,6 +43,7 @@ persistence:
     helm.sh/resource-policy: keep
 
 postgresql:
+  installAsDependency: true
   image:
     tag: 11.14.0-debian-10-r28
   global:


### PR DESCRIPTION
We use Zalando's Postgres Operator to provision pg instances in a controlled way across our infrastructure. This PR contains 2 changes to enable us to use an operator-provisioned db instance instead of a built-in one:

1. Makes installation of the Postgres subchart conditional on a `postgresql.installAsDependency` flag.
2. If that flag is set to `false`, reads the host of the external Postgres from `postgresql.host`.

This PR is tested and working in our setup. Our `values.yaml`:

```
postgresql:
  installAsDependency: false
  host: doccano.postgres.cluster.local
  global:
    postgresql:
      auth:
        database: doccano
        username: doccano
        password: lqGzu!*Dt%MJv*tHH$$Mfa02QNFhOPvp
```